### PR TITLE
PRODENG-4663 rework exporter

### DIFF
--- a/exporter/googlecloudexporter/config.go
+++ b/exporter/googlecloudexporter/config.go
@@ -67,25 +67,4 @@ type LabelMapping struct {
 }
 
 type LogsConfig struct {
-	Resources []LogResource `mapstructure:"resources"`
-}
-
-type LogResource struct {
-	Type           string         `mapstructure:"type"`
-	Name           string         `mapstructure:"name"`
-	Match          LogMatch         `mapstructure:"match"`
-	ResourceLabels []LogOperation `mapstructure:"resource_labels"`
-	LogLabels      []LogOperation `mapstructure:"log_labels"`
-}
-
-type LogOperation struct {
-	Operation string `mapstructure:"operation"`
-	From      string `mapstructure:"from"`
-	To        string `mapstructure:"to"`
-}
-
-type LogMatch struct {
-	Operation string `mapstructure:"operation"`
-	Key      string `mapstructure:"key"`
-	Value        string `mapstructure:"value"`
 }

--- a/exporter/googlecloudexporter/internal/logging.go
+++ b/exporter/googlecloudexporter/internal/logging.go
@@ -17,11 +17,15 @@ package internal
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"path/filepath"
 	"strings"
+
+	conventions "go.opentelemetry.io/collector/translator/conventions/v1.5.0"
 
 	cloudlogging "cloud.google.com/go/logging/apiv2"
 	"go.opentelemetry.io/collector/model/pdata"
-	monitoredres "google.golang.org/genproto/googleapis/api/monitoredres"
+	"google.golang.org/genproto/googleapis/api/monitoredres"
 	ltype "google.golang.org/genproto/googleapis/logging/type"
 	loggingpb "google.golang.org/genproto/googleapis/logging/v2"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -29,16 +33,75 @@ import (
 )
 
 type GoogleLogging struct {
+	// GCP project id
 	ProjectID string
-	client    *cloudlogging.Client
+	// List of labels/attributes to get the log name from
+	LogNameFrom []string
+	// If no log name can be found, defaults to this
+	DefaultLogName string
+	// List of labels/attributes to get the service name from
+	ServiceNameFrom []string
+	// List of labels/attributes to get the service version from
+	ServiceVersionFrom []string
+	// List of labels/attributes to get the file name from
+	FileNameFrom []string
+	// Kubernetes container name label
+	KubernetesContainerLabelFrom string
+	// Kubernetes labels mapping (format is from:to)
+	KubernetesLabelsMapping map[string]string
+
+	client *cloudlogging.Client
 }
+
+const (
+	// default GCP Log name
+	DefaultLogName string = "unknown"
+
+	// additional attributes
+	AttributeLogName            string = "log.name"
+	AttributeFileName           string = "file.name"
+	AttributeFileNameUnderscore string = "file_name"
+
+	// GCP resource types
+	GoogleResourceTypeGlobal              string = "global"
+	GoogleResourceTypeKubernetesContainer string = "k8s_container"
+
+	// GCP resource labels
+	GoogleResourceLabelProjectID     string = "project_id"
+	GoogleResourceLabelLocation      string = "location"
+	GoogleResourceLabelClusterName   string = "cluster_name"
+	GoogleResourceLabelNodeName      string = "node_name"
+	GoogleResourceLabelNamespaceName string = "namespace_name"
+	GoogleResourceLabelPodName       string = "pod_name"
+	GoogleResourceLabelContainerName string = "container_name"
+
+	// GCP Error reporting
+	GoogleServiceContext        string = "serviceContext"
+	GoogleServiceContextService string = "service"
+	GoogleServiceContextVersion string = "version"
+)
 
 func NewGoogleLogging(ctx context.Context, projectID string) *GoogleLogging {
 	client, _ := cloudlogging.NewClient(ctx)
-
+	// inject configuration if needed here
 	return &GoogleLogging{
-		ProjectID: projectID,
-		client:    client,
+		ProjectID:                    projectID,
+		LogNameFrom:                  []string{AttributeLogName, conventions.AttributeServiceName, conventions.AttributeK8SContainerName, conventions.AttributeK8SPodName},
+		DefaultLogName:               DefaultLogName,
+		ServiceNameFrom:              []string{conventions.AttributeServiceName, AttributeLogName, conventions.AttributeK8SContainerName, conventions.AttributeK8SPodName},
+		ServiceVersionFrom:           []string{conventions.AttributeServiceVersion},
+		FileNameFrom:                 []string{AttributeFileName, AttributeFileNameUnderscore},
+		KubernetesContainerLabelFrom: conventions.AttributeK8SContainerName,
+		KubernetesLabelsMapping: map[string]string{
+			conventions.AttributeCloudAccountID:        GoogleResourceLabelProjectID,
+			conventions.AttributeCloudAvailabilityZone: GoogleResourceLabelLocation,
+			conventions.AttributeK8SClusterName:        GoogleResourceLabelClusterName,
+			conventions.AttributeK8SNodeName:           GoogleResourceLabelNodeName,
+			conventions.AttributeK8SNamespaceName:      GoogleResourceLabelNamespaceName,
+			conventions.AttributeK8SPodName:            GoogleResourceLabelPodName,
+			conventions.AttributeK8SContainerName:      GoogleResourceLabelContainerName,
+		},
+		client: client,
 	}
 }
 
@@ -55,14 +118,13 @@ func (b *GoogleLoggingBatch) WriteBatches() {
 	logMap := make(map[string][]*loggingpb.LogEntry)
 	for i := range b.logEntries {
 		entry := b.logEntries[i]
-		logName := entry.LogName
-		entries, ok := logMap[logName]
+		entries, ok := logMap[entry.LogName]
 		if !ok {
 			entries = []*loggingpb.LogEntry{entry}
 		} else {
 			entries = append(entries, entry)
 		}
-		logMap[logName] = entries
+		logMap[entry.LogName] = entries
 	}
 	for logName, entries := range logMap {
 		b.writeBatch(logName, entries)
@@ -79,8 +141,11 @@ func (b *GoogleLoggingBatch) writeBatch(logName string, entries []*loggingpb.Log
 		context.TODO(),
 		&request,
 	)
-	_ = err
-	_ = response
+	if err != nil {
+		// TODO log error here
+	} else {
+		_ = response
+	}
 }
 
 func (gl *GoogleLogging) NewBatch() *GoogleLoggingBatch {
@@ -92,72 +157,119 @@ func (gl *GoogleLogging) NewBatch() *GoogleLoggingBatch {
 
 func (gl *GoogleLogging) ToLogEntries(logs pdata.ResourceLogs) []*loggingpb.LogEntry {
 	il := logs.InstrumentationLibraryLogs()
-	logEnties := make([]*loggingpb.LogEntry, 0)
+	logEntries := make([]*loggingpb.LogEntry, 0)
 	for i := 0; i < il.Len(); i++ {
 		l := il.At(i)
 		logSlice := l.Logs()
 		for j := 0; j < logSlice.Len(); j++ {
-			logEnties = append(logEnties, gl.ToLogEntry(logs, l, logSlice.At(j)))
+			logEntries = append(logEntries, gl.ToLogEntry(logs, l, logSlice.At(j)))
 		}
-		//rl := te.lexporter.ToLogEntries(l.)
-		//logEntries = append(logEntries, rl...)
 	}
-
-	return logEnties
-
+	return logEntries
 }
 
-func (gl *GoogleLogging) addBodyToPayload(entry *loggingpb.LogEntry, value pdata.AttributeValue, service string) error {
+func (gl *GoogleLogging) Shutdown(context.Context) error {
+	return gl.client.Close()
+}
+
+func (gl *GoogleLogging) ToLogEntry(logs pdata.ResourceLogs, il pdata.InstrumentationLibraryLogs, logRecord pdata.LogRecord) *loggingpb.LogEntry {
+	// default resource
+	monitoredResource := &monitoredres.MonitoredResource{Type: GoogleResourceTypeGlobal}
+
+	labels := extractLabels(logs, il, logRecord)
+
+	// convert to Kubernetes container resource
+	if container, found := labels[gl.KubernetesContainerLabelFrom]; found && container != "" {
+		monitoredResource = gl.getKubernetesContainerResource(labels)
+	}
+
+	entry := &loggingpb.LogEntry{
+		Timestamp: &timestamppb.Timestamp{
+			Seconds: logRecord.Timestamp().AsTime().Unix(),
+			Nanos:   int32(logRecord.Timestamp().AsTime().Nanosecond()),
+		},
+		Labels:         labels,
+		Resource:       monitoredResource,
+		LogName:        gl.getLogName(labels),
+		Severity:       getSeverity(logRecord.SeverityText()),
+		HttpRequest:    getHTTPRequest(logRecord),
+		SourceLocation: getSourceLocation(logRecord),
+	}
+
+	// build a service context
+	var serviceContext map[string]interface{}
+	if serviceName, found := getFirstNotEmptyLabel(labels, gl.ServiceNameFrom); found {
+		serviceContext = gl.getServiceContext(serviceName, labels)
+	}
+
+	// build the body
+	if err := gl.addBodyToLogEntry(entry, logRecord.Body(), serviceContext); err != nil {
+		// TODO log error
+		_ = err
+	}
+
+	// add trace data
+	gl.addTraceToLogEntry(entry, logRecord)
+
+	return entry
+}
+
+// See https://cloud.google.com/logging/docs/api/v2/resource-list#resource-types
+func (gl *GoogleLogging) getKubernetesContainerResource(labels map[string]string) *monitoredres.MonitoredResource {
+	k8sLabels := map[string]string{}
+	for from, to := range gl.KubernetesLabelsMapping {
+		if v, found := labels[from]; found && v != "" {
+			k8sLabels[to] = v
+		}
+	}
+	return &monitoredres.MonitoredResource{Type: GoogleResourceTypeKubernetesContainer, Labels: k8sLabels}
+}
+
+func (gl *GoogleLogging) getLogName(labels map[string]string) string {
+	logName, found := getFirstNotEmptyLabel(labels, gl.LogNameFrom)
+	if !found {
+		if fileName, found := getFirstNotEmptyLabel(labels, gl.FileNameFrom); found {
+			logName = strings.TrimSuffix(fileName, filepath.Ext(fileName))
+			if idx := strings.Index(fileName, "-"); idx >= 0 {
+				logName = logName[:idx]
+			}
+		} else {
+			logName = gl.DefaultLogName
+		}
+	}
+	return fmt.Sprintf("projects/%s/logs/%s", gl.ProjectID, url.QueryEscape(logName))
+}
+
+func (gl *GoogleLogging) addBodyToLogEntry(entry *loggingpb.LogEntry, value pdata.AttributeValue, serviceContext map[string]interface{}) error {
 	switch value.Type() {
 	case pdata.AttributeValueTypeString:
+		// TODO detect JSON payload?
 		entry.Payload = &loggingpb.LogEntry_TextPayload{
 			TextPayload: value.StringVal(),
 		}
-		break
-	case pdata.AttributeValueTypeInt:
-		break
-	case pdata.AttributeValueTypeDouble:
-		break
-	case pdata.AttributeValueTypeBool:
-		break
 	case pdata.AttributeValueTypeMap:
-		converted := gl.treeWalker(value.MapVal())
-		if converted["serviceContext"] == nil && service != "" {
-			converted["serviceContext"] = map[string]interface{} {
-				"service": service,
-			}
+		converted := pdata.AttributeMapToMap(value.MapVal())
+
+		// inject service context for GCP Error reporting
+		if converted[GoogleServiceContext] == nil && len(serviceContext) > 0 {
+			converted[GoogleServiceContext] = serviceContext
 		}
-		json, _ := structpb.NewStruct(converted)
+
+		json, err := structpb.NewStruct(converted)
+		if err != nil {
+			return err
+		}
+
 		entry.Payload = &loggingpb.LogEntry_JsonPayload{
 			JsonPayload: json,
 		}
-		break
+	case pdata.AttributeValueTypeInt:
+	case pdata.AttributeValueTypeDouble:
+	case pdata.AttributeValueTypeBool:
 	case pdata.AttributeValueTypeArray:
-		break
 	case pdata.AttributeValueTypeNull:
 	}
 	return nil
-}
-
-func (gl *GoogleLogging) treeWalker(attrMap pdata.AttributeMap) map[string]interface{} {
-	out := make(map[string]interface{}, attrMap.Len())
-
-	attrMap.Range(func(key string, value pdata.AttributeValue) bool {
-		switch value.Type() {
-		case pdata.AttributeValueTypeMap:
-			out[key] = gl.treeWalker(value.MapVal())
-		case pdata.AttributeValueTypeString:
-			out[key] = value.StringVal()
-		case pdata.AttributeValueTypeBool:
-			out[key] = value.BoolVal()
-		case pdata.AttributeValueTypeDouble:
-			out[key] = value.DoubleVal()
-		case pdata.AttributeValueTypeInt:
-			out[key] = value.IntVal()
-		}
-		return true
-	})
-	return out
 }
 
 func (gl *GoogleLogging) addTraceToLogEntry(entry *loggingpb.LogEntry, logRecord pdata.LogRecord) {
@@ -175,50 +287,7 @@ func (gl *GoogleLogging) addTraceToLogEntry(entry *loggingpb.LogEntry, logRecord
 	}
 }
 
-func (gl *GoogleLogging) ExtractResource(logs pdata.ResourceLogs, logRecord pdata.LogRecord) *monitoredres.MonitoredResource {
-
-	monitoredResource := &monitoredres.MonitoredResource{Type: "global"}
-	//fileName, ok := logRecord.Attributes().Get("file_name")
-	//if !ok {
-	//	fileName, ok = logRecord.Attributes().Get("file.name")
-	//}
-	//job := ""
-	//if ok {
-	//	value := fileName.StringVal()
-	//	if strings.Contains(value, "postgresql") {
-	//		job = "postgresql"
-	//	} else if strings.Contains(value,"dgc") {
-	//		job = "dgc"
-	//	} else if strings.Contains(value,"console") {
-	//		job = "console"
-	//	}
-	//}
-
-	//if job != "" {
-	//	monitoredResource.Type = "generic_task"
-	//	monitoredResource.Labels = map[string]string{
-	//		"project_id": "collibra-telemetry",
-	//		"job":        job,
-	//	}
-	//	zone, _ := logs.Resource().Attributes().Get("cloud.availability_zone")
-	//	accountId, _ := logs.Resource().Attributes().Get("cloud.account.id")
-	//	if ok {
-	//		monitoredResource.Labels["location"] = fmt.Sprintf("aws:%s:%s", accountId.StringVal(), zone.StringVal())
-	//	}
-	//	envName, _ := logs.Resource().Attributes().Get("collibra.instance.environment_name")
-	//	if ok {
-	//		monitoredResource.Labels["namespace"] = envName.StringVal()
-	//	}
-	//	value, ok := logs.Resource().Attributes().Get("host.id")
-	//	if ok {
-	//		monitoredResource.Labels["task_id"] = value.StringVal()
-	//	}
-	//}
-
-	return monitoredResource
-}
-
-func (gl *GoogleLogging) ToLabels(logs pdata.ResourceLogs, il pdata.InstrumentationLibraryLogs, logRecord pdata.LogRecord) map[string]string {
+func extractLabels(logs pdata.ResourceLogs, il pdata.InstrumentationLibraryLogs, logRecord pdata.LogRecord) map[string]string {
 	labels := map[string]string{}
 	logs.Resource().Attributes().Range(func(k string, v pdata.AttributeValue) bool {
 		labels[k] = v.StringVal()
@@ -238,110 +307,57 @@ func (gl *GoogleLogging) ToLabels(logs pdata.ResourceLogs, il pdata.Instrumentat
 	return labels
 }
 
-func (gl *GoogleLogging) ToLogEntry(logs pdata.ResourceLogs, il pdata.InstrumentationLibraryLogs, logRecord pdata.LogRecord) *loggingpb.LogEntry {
+func getSeverity(severityText string) ltype.LogSeverity {
+	severity := ltype.LogSeverity_DEFAULT
+	switch severityText = strings.ToUpper(severityText); {
+	case strings.HasPrefix(severityText, "TRACE"):
+		severity = ltype.LogSeverity_DEFAULT
+	case strings.HasPrefix(severityText, "DEBUG"):
+		severity = ltype.LogSeverity_DEBUG
+	case strings.HasPrefix(severityText, "INFO"):
+		severity = ltype.LogSeverity_INFO
+	case strings.HasPrefix(severityText, "WARN"):
+		severity = ltype.LogSeverity_WARNING
+	case strings.HasPrefix(severityText, "ERROR"):
+		severity = ltype.LogSeverity_ERROR
+	case strings.HasPrefix(severityText, "FATAL"):
+		severity = ltype.LogSeverity_CRITICAL
+	}
+	return severity
+}
 
-	monitoredResource := gl.ExtractResource(logs, logRecord)
-	entry := &loggingpb.LogEntry{
-		Timestamp: &timestamppb.Timestamp{
-			Seconds: logRecord.Timestamp().AsTime().Unix(),
-			Nanos:   int32(logRecord.Timestamp().AsTime().Nanosecond()),
-		},
-		Labels:   gl.ToLabels(logs, il, logRecord),
-		Resource: monitoredResource,
+// create service context for GCP Error reporting
+// ref: https://cloud.google.com/error-reporting/docs/formatting-error-messages
+func (gl *GoogleLogging) getServiceContext(serviceName string, labels map[string]string) map[string]interface{} {
+	serviceContext := map[string]interface{}{
+		GoogleServiceContextService: serviceName,
 	}
-	fileName, ok := logRecord.Attributes().Get("file_name")
-	if !ok {
-		fileName, ok = logRecord.Attributes().Get("file.name")
+	if version, found := getFirstNotEmptyLabel(labels, gl.ServiceVersionFrom); found {
+		serviceContext[GoogleServiceContextVersion] = version
 	}
-	logName := "unknown"
-	service := ""
-	if ok {
-		value := fileName.StringVal()
-		if strings.HasPrefix(value, "postgresql") {
-			logName = "postgresql"
-			service = "postgresql"
-		} else if strings.HasPrefix(value, "dgc") {
-			logName = "dgc"
-			service = "dgc"
-		} else if strings.HasPrefix(value, "json_access") {
-			logName = "apache-access"
-			service = "apache"
-		} else if strings.HasPrefix(value, "json_error") {
-			logName = "apache-error"
-			service = "apache"
-		} else if strings.HasPrefix(value, "console") {
-			logName = "console"
-			service = "console"
-		} else if strings.HasPrefix(value, "agent") {
-			logName = "agent"
-			service = "agent"
-		} else if strings.HasPrefix(value, "istio.err") {
-			logName = "istio-vm-error"
-			service = "istio"
-		} else if strings.HasPrefix(value, "istio") {
-			logName = "istio-vm-access"
-			service = "istip"
-		} else if strings.HasPrefix(value, "spark-job-server") {
-			logName = "spark-job-server"
-			service = "spark-job-server"
-		} else if strings.HasPrefix(value, "yum") {
-			logName = "yum"
-			service = "yum"
+	return serviceContext
+}
+
+// ref. https://pkg.go.dev/google.golang.org/genproto@v0.0.0-20211019152133-63b7e35f4404/googleapis/logging/type#HttpRequest
+func getHTTPRequest(logRecord pdata.LogRecord) *ltype.HttpRequest {
+	// To be implemented
+	return nil
+}
+
+// ref. https://pkg.go.dev/google.golang.org/genproto/googleapis/logging/v2?utm_source=gopls#LogEntrySourceLocation
+func getSourceLocation(logRecord pdata.LogRecord) *loggingpb.LogEntrySourceLocation {
+	// To be implemented
+	return nil
+}
+
+// getFirstNotEmptyLabel finds the first not empty label in the provided labels from the list of keys
+// returns the value and a bool to know if a not empty value has been found
+func getFirstNotEmptyLabel(labels map[string]string, keys []string) (string, bool) {
+	for i := range keys {
+		key := keys[i]
+		if value, found := labels[key]; found && value != "" {
+			return value, true
 		}
 	}
-	entry.LogName = fmt.Sprintf("projects/collibra-telemetry/logs/%s", logName)
-
-	gl.addBodyToPayload(entry, logRecord.Body(), service)
-	gl.addTraceToLogEntry(entry, logRecord)
-	switch strings.ToUpper(logRecord.SeverityText()) {
-	case "TRACE":
-		entry.Severity = ltype.LogSeverity_DEFAULT
-	case "TRACE2":
-		entry.Severity = ltype.LogSeverity_DEFAULT
-	case "TRACE3":
-		entry.Severity = ltype.LogSeverity_DEFAULT
-	case "TRACE4":
-		entry.Severity = ltype.LogSeverity_DEFAULT
-	case "DEBUG":
-		entry.Severity = ltype.LogSeverity_DEBUG
-	case "DEBUG2":
-		entry.Severity = ltype.LogSeverity_DEBUG
-	case "DEBUG3":
-		entry.Severity = ltype.LogSeverity_DEBUG
-	case "DEBUG4":
-		entry.Severity = ltype.LogSeverity_DEBUG
-	case "INFO":
-		entry.Severity = ltype.LogSeverity_INFO
-	case "INFO2":
-		entry.Severity = ltype.LogSeverity_INFO
-	case "INFO3":
-		entry.Severity = ltype.LogSeverity_INFO
-	case "INFO4":
-		entry.Severity = ltype.LogSeverity_INFO
-	case "WARN":
-		entry.Severity = ltype.LogSeverity_WARNING
-	case "WARN2":
-		entry.Severity = ltype.LogSeverity_WARNING
-	case "WARN3":
-		entry.Severity = ltype.LogSeverity_WARNING
-	case "WARN4":
-		entry.Severity = ltype.LogSeverity_WARNING
-	case "ERROR":
-		entry.Severity = ltype.LogSeverity_ERROR
-	case "ERROR2":
-		entry.Severity = ltype.LogSeverity_ERROR
-	case "ERROR3":
-		entry.Severity = ltype.LogSeverity_ERROR
-	case "ERROR4":
-		entry.Severity = ltype.LogSeverity_ERROR
-	case "FATAL":
-		entry.Severity = ltype.LogSeverity_CRITICAL
-	case "FATAL2":
-		entry.Severity = ltype.LogSeverity_CRITICAL
-	case "FATAL3":
-		entry.Severity = ltype.LogSeverity_CRITICAL
-	case "FATAL4":
-		entry.Severity = ltype.LogSeverity_CRITICAL
-	}
-	return entry
+	return "", false
 }

--- a/exporter/googlecloudexporter/internal/logging_test.go
+++ b/exporter/googlecloudexporter/internal/logging_test.go
@@ -1,0 +1,723 @@
+package internal
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/model/pdata"
+	"google.golang.org/genproto/googleapis/api/monitoredres"
+	ltype "google.golang.org/genproto/googleapis/logging/type"
+	loggingpb "google.golang.org/genproto/googleapis/logging/v2"
+)
+
+func TestGoogleLogging_ToLogEntry(t *testing.T) {
+	type args struct {
+		logs      pdata.ResourceLogs
+		il        pdata.InstrumentationLibraryLogs
+		logRecord pdata.LogRecord
+	}
+	tests := []struct {
+		name string
+		args args
+		want *loggingpb.LogEntry
+	}{
+		{
+			name: "Empty",
+			args: args{
+				logs:      newResourceLogs(map[string]pdata.AttributeValue{}),
+				il:        newInstrumentationLibraryLogs("", ""),
+				logRecord: newLogRecord(map[string]pdata.AttributeValue{}),
+			},
+			want: &loggingpb.LogEntry{
+				Timestamp: timestamppb.New(time.UnixMilli(0)),
+				Resource:  &monitoredres.MonitoredResource{Type: "global"},
+				LogName:   "projects/my-project-id/logs/unknown",
+				Labels:    map[string]string{},
+			},
+		},
+		{
+			name: "VM-like logs",
+			args: args{
+				logs: newResourceLogs(map[string]pdata.AttributeValue{
+					"service.namespace":   pdata.NewAttributeValueString("cdic"),
+					"service.name":        pdata.NewAttributeValueString("dgc"),
+					"service.instance.id": pdata.NewAttributeValueString("xxxx-yyyy-zzzz"),
+					"service.version":     pdata.NewAttributeValueString("yyyy.mm.pp-bb"),
+				}),
+				il: newInstrumentationLibraryLogs("my-lib", "999.999.999"),
+				logRecord: newLogRecordWithBody(map[string]pdata.AttributeValue{
+					"file.name": pdata.NewAttributeValueString("dgc.jsonl"),
+					"log.name":  pdata.NewAttributeValueString("dgc"),
+				}, newAttributeMap(map[string]pdata.AttributeValue{
+					"level":   pdata.NewAttributeValueString("INFO"),
+					"message": pdata.NewAttributeValueString("Hello world"),
+				})),
+			},
+			want: &loggingpb.LogEntry{
+				Timestamp: timestamppb.New(time.UnixMilli(0)),
+				Resource:  &monitoredres.MonitoredResource{Type: "global"},
+				LogName:   "projects/my-project-id/logs/dgc",
+				Labels: map[string]string{
+					"service.namespace":                      "cdic",
+					"service.name":                           "dgc",
+					"service.instance.id":                    "xxxx-yyyy-zzzz",
+					"service.version":                        "yyyy.mm.pp-bb",
+					"file.name":                              "dgc.jsonl",
+					"log.name":                               "dgc",
+					"opentelemetry.org/instrumentation/name": "my-lib",
+					"opentelemetry.org/instrumentation/version": "999.999.999",
+				},
+				Payload: &loggingpb.LogEntry_JsonPayload{
+					JsonPayload: newBodyStruct(map[string]interface{}{
+						"level":   "INFO",
+						"message": "Hello world",
+						"serviceContext": map[string]interface{}{
+							"service": "dgc",
+							"version": "yyyy.mm.pp-bb",
+						},
+					}),
+				},
+			},
+		},
+		{
+			name: "VM-like logs (without OTel semantic fields)",
+			args: args{
+				logs: newResourceLogs(map[string]pdata.AttributeValue{}),
+				il:   newInstrumentationLibraryLogs("my-lib", "999.999.999"),
+				logRecord: newLogRecordWithBody(map[string]pdata.AttributeValue{
+					"file.name": pdata.NewAttributeValueString("dgc.jsonl"),
+				}, newAttributeMap(map[string]pdata.AttributeValue{
+					"level":   pdata.NewAttributeValueString("INFO"),
+					"message": pdata.NewAttributeValueString("Hello world"),
+				})),
+			},
+			want: &loggingpb.LogEntry{
+				Timestamp: timestamppb.New(time.UnixMilli(0)),
+				Resource:  &monitoredres.MonitoredResource{Type: "global"},
+				LogName:   "projects/my-project-id/logs/dgc",
+				Labels: map[string]string{
+					"file.name":                                 "dgc.jsonl",
+					"opentelemetry.org/instrumentation/name":    "my-lib",
+					"opentelemetry.org/instrumentation/version": "999.999.999",
+				},
+				Payload: &loggingpb.LogEntry_JsonPayload{
+					JsonPayload: newBodyStruct(map[string]interface{}{
+						"level":   "INFO",
+						"message": "Hello world",
+					}),
+				},
+			},
+		},
+		{
+			name: "K8s-like logs",
+			args: args{
+				logs: newResourceLogs(map[string]pdata.AttributeValue{
+					"cloud.account.id":        pdata.NewAttributeValueString("my-account-id"),
+					"cloud.availability_zone": pdata.NewAttributeValueString("eu-somewhere-1"),
+					"k8s.cluster.name":        pdata.NewAttributeValueString("cluster-name"),
+					"k8s.node.name":           pdata.NewAttributeValueString("node-name"),
+					"k8s.namespace.name":      pdata.NewAttributeValueString("cdic-xxxx-yyyy-zzzz"),
+					"k8s.pod.name":            pdata.NewAttributeValueString("dgc-core-xxxxx"),
+					"k8s.container.name":      pdata.NewAttributeValueString("dgc-core"),
+				}),
+				il: newInstrumentationLibraryLogs("my-lib", "999.999.999"),
+				logRecord: newLogRecordWithBody(map[string]pdata.AttributeValue{
+					"file.name": pdata.NewAttributeValueString("dgc-core-xxxxx.log"),
+				}, newAttributeMap(map[string]pdata.AttributeValue{
+					"level":   pdata.NewAttributeValueString("INFO"),
+					"message": pdata.NewAttributeValueString("Hello world"),
+				})),
+			},
+			want: &loggingpb.LogEntry{
+				Timestamp: timestamppb.New(time.UnixMilli(0)),
+				Resource: &monitoredres.MonitoredResource{
+					Type: "k8s_container",
+					Labels: map[string]string{
+						"project_id":     "my-account-id",
+						"location":       "eu-somewhere-1",
+						"cluster_name":   "cluster-name",
+						"node_name":      "node-name",
+						"namespace_name": "cdic-xxxx-yyyy-zzzz",
+						"pod_name":       "dgc-core-xxxxx",
+						"container_name": "dgc-core",
+					},
+				},
+				LogName: "projects/my-project-id/logs/dgc-core",
+				Labels: map[string]string{
+					"cloud.account.id":                          "my-account-id",
+					"cloud.availability_zone":                   "eu-somewhere-1",
+					"k8s.cluster.name":                          "cluster-name",
+					"k8s.node.name":                             "node-name",
+					"k8s.namespace.name":                        "cdic-xxxx-yyyy-zzzz",
+					"k8s.pod.name":                              "dgc-core-xxxxx",
+					"k8s.container.name":                        "dgc-core",
+					"file.name":                                 "dgc-core-xxxxx.log",
+					"opentelemetry.org/instrumentation/name":    "my-lib",
+					"opentelemetry.org/instrumentation/version": "999.999.999",
+				},
+				Payload: &loggingpb.LogEntry_JsonPayload{
+					JsonPayload: newBodyStruct(map[string]interface{}{
+						"level":          "INFO",
+						"message":        "Hello world",
+						"serviceContext": map[string]interface{}{"service": "dgc-core"},
+					}),
+				},
+			},
+		},
+	}
+	gl := NewGoogleLogging(context.Background(), "my-project-id")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := gl.ToLogEntry(tt.args.logs, tt.args.il, tt.args.logRecord)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGoogleLogging_addBodyToLogEntry(t *testing.T) {
+	type args struct {
+		entry          *loggingpb.LogEntry
+		body           pdata.AttributeValue
+		serviceContext map[string]interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+		want loggingpb.LogEntry
+	}{
+		{
+			name: "Empty",
+			args: args{
+				entry:          &loggingpb.LogEntry{},
+				body:           pdata.NewAttributeValueNull(),
+				serviceContext: nil,
+			},
+			want: loggingpb.LogEntry{},
+		},
+		{
+			name: "Text payload",
+			args: args{
+				entry:          &loggingpb.LogEntry{},
+				body:           pdata.NewAttributeValueString("some body here"),
+				serviceContext: map[string]interface{}{"not": "supported"},
+			},
+			want: loggingpb.LogEntry{
+				Payload: &loggingpb.LogEntry_TextPayload{TextPayload: "some body here"},
+			},
+		},
+		{
+			name: "JSON payload",
+			args: args{
+				entry: &loggingpb.LogEntry{},
+				body: newAttributeMap(map[string]pdata.AttributeValue{
+					"level":   pdata.NewAttributeValueString("severely-burned"),
+					"message": pdata.NewAttributeValueString("Hello world"),
+				}),
+				serviceContext: map[string]interface{}{"some": "stuff"},
+			},
+			want: loggingpb.LogEntry{
+				Payload: &loggingpb.LogEntry_JsonPayload{
+					JsonPayload: newBodyStruct(map[string]interface{}{
+						"level":          "severely-burned",
+						"message":        "Hello world",
+						"serviceContext": map[string]interface{}{"some": "stuff"},
+					}),
+				},
+			},
+		},
+		{
+			name: "JSON payload, no service context",
+			args: args{
+				entry: &loggingpb.LogEntry{},
+				body: newAttributeMap(map[string]pdata.AttributeValue{
+					"level":   pdata.NewAttributeValueString("informal"),
+					"message": pdata.NewAttributeValueString("Hello universe"),
+				}),
+				serviceContext: nil,
+			},
+			want: loggingpb.LogEntry{
+				Payload: &loggingpb.LogEntry_JsonPayload{
+					JsonPayload: newBodyStruct(map[string]interface{}{
+						"level":   "informal",
+						"message": "Hello universe",
+					}),
+				},
+			},
+		},
+	}
+	gl := NewGoogleLogging(context.Background(), "my-project-id")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := gl.addBodyToLogEntry(tt.args.entry, tt.args.body, tt.args.serviceContext)
+			assert.NoError(t, err)
+			got := *tt.args.entry
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGoogleLogging_addTraceToLogEntry(t *testing.T) {
+	type args struct {
+		entry     *loggingpb.LogEntry
+		logRecord pdata.LogRecord
+	}
+
+	traceID := [16]byte{0x12, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78}
+	spanID := [8]byte{0x12, 0x23, 0xAD, 0x12, 0x23, 0xAD, 0x12, 0x23}
+
+	tests := []struct {
+		name string
+		args args
+		want loggingpb.LogEntry
+	}{
+		{
+			name: "Empty",
+			args: args{
+				entry:     &loggingpb.LogEntry{},
+				logRecord: newLogRecord(map[string]pdata.AttributeValue{}),
+			},
+			want: loggingpb.LogEntry{},
+		},
+		{
+			name: "Not sampled",
+			args: args{
+				entry:     &loggingpb.LogEntry{},
+				logRecord: newLogRecordWithTraces(traceID, spanID, 0x00),
+			},
+			want: loggingpb.LogEntry{
+				Trace:        "projects/my-project-id/traces/12345678123456781234567812345678",
+				SpanId:       "1223ad1223ad1223",
+				TraceSampled: false,
+			},
+		},
+		{
+			name: "Full",
+			args: args{
+				entry:     &loggingpb.LogEntry{},
+				logRecord: newLogRecordWithTraces(traceID, spanID, 0x01),
+			},
+			want: loggingpb.LogEntry{
+				Trace:        "projects/my-project-id/traces/12345678123456781234567812345678",
+				SpanId:       "1223ad1223ad1223",
+				TraceSampled: true,
+			},
+		},
+	}
+	gl := NewGoogleLogging(context.Background(), "my-project-id")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gl.addTraceToLogEntry(tt.args.entry, tt.args.logRecord)
+			got := *tt.args.entry
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGoogleLogging_getKubernetesContainerResource(t *testing.T) {
+	tests := []struct {
+		name   string
+		labels map[string]string
+		want   *monitoredres.MonitoredResource
+	}{
+		{
+			name:   "Empty",
+			labels: nil,
+			want:   &monitoredres.MonitoredResource{Type: "k8s_container", Labels: map[string]string{}},
+		},
+		{
+			name:   "Some labels",
+			labels: map[string]string{"some": "labels"},
+			want:   &monitoredres.MonitoredResource{Type: "k8s_container", Labels: map[string]string{}},
+		},
+		{
+			name: "All Kubernetes labels",
+			labels: map[string]string{
+				"cloud.account.id":        "some-id",
+				"cloud.availability_zone": "eu-somewhere-1a",
+				"k8s.cluster.name":        "cluster-name",
+				"k8s.node.name":           "node-name",
+				"k8s.namespace.name":      "namespace-name",
+				"k8s.pod.name":            "pod-name",
+				"k8s.container.name":      "container-name",
+			},
+			want: &monitoredres.MonitoredResource{
+				Type: "k8s_container",
+				Labels: map[string]string{
+					"project_id":     "some-id",
+					"location":       "eu-somewhere-1a",
+					"cluster_name":   "cluster-name",
+					"node_name":      "node-name",
+					"namespace_name": "namespace-name",
+					"pod_name":       "pod-name",
+					"container_name": "container-name",
+				},
+			},
+		},
+		{
+			name: "Partial Kubernetes labels",
+			labels: map[string]string{
+				"k8s.container.name": "container-name",
+			},
+			want: &monitoredres.MonitoredResource{
+				Type: "k8s_container",
+				Labels: map[string]string{
+					"container_name": "container-name",
+				},
+			},
+		},
+	}
+	gl := NewGoogleLogging(context.Background(), "my-project-id")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := gl.getKubernetesContainerResource(tt.labels)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGoogleLogging_getLogName(t *testing.T) {
+	tests := []struct {
+		name   string
+		labels map[string]string
+		want   string
+	}{
+		{
+			name:   "Empty",
+			labels: nil,
+			want:   "projects/my-project-id/logs/unknown",
+		},
+		{
+			name:   "Encoded log name",
+			labels: map[string]string{"log.name": "hello/world"},
+			want:   "projects/my-project-id/logs/hello%2Fworld",
+		},
+		{
+			name:   "Fallback on file name",
+			labels: map[string]string{"file.name": "hello"},
+			want:   "projects/my-project-id/logs/hello",
+		},
+		{
+			name:   "Extract log name from file name with date",
+			labels: map[string]string{"file.name": "hello-yyyy-mm-dd.log"},
+			want:   "projects/my-project-id/logs/hello",
+		},
+		{
+			name:   "Extract log name from file name",
+			labels: map[string]string{"file.name": "hello.log"},
+			want:   "projects/my-project-id/logs/hello",
+		},
+	}
+	gl := NewGoogleLogging(context.Background(), "my-project-id")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := gl.getLogName(tt.labels)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_extractLabels(t *testing.T) {
+	type args struct {
+		logs      pdata.ResourceLogs
+		il        pdata.InstrumentationLibraryLogs
+		logRecord pdata.LogRecord
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[string]string
+	}{
+		{
+			name: "Empty",
+			args: args{
+				logs:      newResourceLogs(map[string]pdata.AttributeValue{}),
+				il:        newInstrumentationLibraryLogs("", ""),
+				logRecord: newLogRecord(map[string]pdata.AttributeValue{}),
+			},
+			want: map[string]string{},
+		},
+		{
+			name: "Instrumentation library",
+			args: args{
+				logs:      newResourceLogs(map[string]pdata.AttributeValue{}),
+				il:        newInstrumentationLibraryLogs("my-name", "0.0.1-alpha5"),
+				logRecord: newLogRecord(map[string]pdata.AttributeValue{}),
+			},
+			want: map[string]string{
+				"opentelemetry.org/instrumentation/name":    "my-name",
+				"opentelemetry.org/instrumentation/version": "0.0.1-alpha5",
+			},
+		},
+		{
+			name: "Full example",
+			args: args{
+				logs: newResourceLogs(map[string]pdata.AttributeValue{
+					"resource-logs": pdata.NewAttributeValueString("other value here"),
+					"some-key":      pdata.NewAttributeValueString("resource logs"),
+				}),
+				il: newInstrumentationLibraryLogs("hello", "0.0.2-beta1"),
+				logRecord: newLogRecord(map[string]pdata.AttributeValue{
+					"log-record": pdata.NewAttributeValueString("value here"),
+					"some-key":   pdata.NewAttributeValueString("log record"),
+				}),
+			},
+			want: map[string]string{
+				"resource-logs":                          "other value here",
+				"log-record":                             "value here",
+				"some-key":                               "log record",
+				"opentelemetry.org/instrumentation/name": "hello",
+				"opentelemetry.org/instrumentation/version": "0.0.2-beta1",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractLabels(tt.args.logs, tt.args.il, tt.args.logRecord)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGoogleLogging_getServiceContext(t *testing.T) {
+	type args struct {
+		serviceName string
+		labels      map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[string]interface{}
+	}{
+		{
+			name: "Empty",
+			args: args{},
+			want: map[string]interface{}{"service": ""},
+		},
+		{
+			name: "No version",
+			args: args{
+				serviceName: "my-service",
+				labels:      map[string]string{},
+			},
+			want: map[string]interface{}{"service": "my-service"},
+		},
+		{
+			name: "Full",
+			args: args{
+				serviceName: "service-b",
+				labels:      map[string]string{"service.version": "0.0.1-alpha3"},
+			},
+			want: map[string]interface{}{
+				"service": "service-b",
+				"version": "0.0.1-alpha3",
+			},
+		},
+	}
+	gl := NewGoogleLogging(context.Background(), "my-project-id")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := gl.getServiceContext(tt.args.serviceName, tt.args.labels)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_getFirstNotEmptyLabel(t *testing.T) {
+	type args struct {
+		labels map[string]string
+		keys   []string
+	}
+	type result struct {
+		value string
+		found bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want result
+	}{
+		{
+			name: "Empty labels",
+			args: args{
+				labels: nil,
+				keys:   nil,
+			},
+			want: result{value: "", found: false},
+		},
+		{
+			name: "Not found",
+			args: args{
+				labels: map[string]string{
+					"stuff": "here",
+					"hello": "world",
+				},
+				keys: []string{"nope", "not.here"},
+			},
+			want: result{value: "", found: false},
+		},
+		{
+			name: "One key",
+			args: args{
+				labels: map[string]string{
+					"stuff": "here",
+					"hello": "world",
+					"extra": "!",
+				},
+				keys: []string{"stuff"},
+			},
+			want: result{value: "here", found: true},
+		},
+		{
+			name: "Multiple keys",
+			args: args{
+				labels: map[string]string{
+					"stuff": "here",
+					"hello": "world",
+					"extra": "!",
+				},
+				keys: []string{"hello", "stuff", "extra"},
+			},
+			want: result{value: "world", found: true},
+		},
+		{
+			name: "Multiple keys with empty value",
+			args: args{
+				labels: map[string]string{
+					"hello": "",
+					"extra": "!",
+				},
+				keys: []string{"hello", "stuff", "extra"},
+			},
+			want: result{value: "!", found: true},
+		},
+		{
+			name: "Multiple keys with only empty values",
+			args: args{
+				labels: map[string]string{
+					"stuff": "",
+					"hello": "",
+					"extra": "",
+				},
+				keys: []string{"hello", "stuff", "extra"},
+			},
+			want: result{value: "", found: false},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			value, found := getFirstNotEmptyLabel(tt.args.labels, tt.args.keys)
+			got := result{value: value, found: found}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_getSeverity(t *testing.T) {
+	tests := []struct {
+		name string
+		args string
+		want ltype.LogSeverity
+	}{
+		{
+			name: "Empty",
+			args: "",
+			want: ltype.LogSeverity_DEFAULT,
+		}, {
+			name: "Non-matched",
+			args: "whatever",
+			want: ltype.LogSeverity_DEFAULT,
+		}, {
+			name: "Trace",
+			args: "trace",
+			want: ltype.LogSeverity_DEFAULT,
+		}, {
+			name: "Trace (by prefix)",
+			args: "TRACE5",
+			want: ltype.LogSeverity_DEFAULT,
+		}, {
+			name: "Debug",
+			args: "debug",
+			want: ltype.LogSeverity_DEBUG,
+		}, {
+			name: "Info",
+			args: "info",
+			want: ltype.LogSeverity_INFO,
+		}, {
+			name: "Warning",
+			args: "warn",
+			want: ltype.LogSeverity_WARNING,
+		}, {
+			name: "Error",
+			args: "error",
+			want: ltype.LogSeverity_ERROR,
+		}, {
+			name: "Critical",
+			args: "fatal",
+			want: ltype.LogSeverity_CRITICAL,
+		}, {
+			name: "Crazy stuff",
+			args: "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+			want: ltype.LogSeverity_DEFAULT,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getSeverity(tt.args)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// helpers
+
+func newResourceLogs(attr map[string]pdata.AttributeValue) pdata.ResourceLogs {
+	resourceLogs := pdata.NewResourceLogs()
+	resourceLogs.Resource().Attributes().InitFromMap(attr)
+	return resourceLogs
+}
+
+func newInstrumentationLibraryLogs(name, version string) pdata.InstrumentationLibraryLogs {
+	il := pdata.NewInstrumentationLibraryLogs()
+	il.InstrumentationLibrary().SetName(name)
+	il.InstrumentationLibrary().SetVersion(version)
+	return il
+}
+
+func newLogRecord(attr map[string]pdata.AttributeValue) pdata.LogRecord {
+	logRecord := pdata.NewLogRecord()
+	logRecord.SetTimestamp(pdata.TimestampFromTime(time.UnixMilli(0)))
+	logRecord.Attributes().InitFromMap(attr)
+	return logRecord
+}
+
+func newLogRecordWithBody(attr map[string]pdata.AttributeValue, body pdata.AttributeValue) pdata.LogRecord {
+	logRecord := pdata.NewLogRecord()
+	logRecord.SetTimestamp(pdata.TimestampFromTime(time.UnixMilli(0)))
+	logRecord.Attributes().InitFromMap(attr)
+	body.CopyTo(logRecord.Body())
+	return logRecord
+}
+
+func newLogRecordWithTraces(traceID [16]byte, spanID [8]byte, flags uint32) pdata.LogRecord {
+	logRecord := pdata.NewLogRecord()
+	logRecord.SetTraceID(pdata.NewTraceID(traceID))
+	logRecord.SetSpanID(pdata.NewSpanID(spanID))
+	logRecord.SetFlags(flags)
+	return logRecord
+}
+
+func newBodyStruct(input map[string]interface{}) *structpb.Struct {
+	s, _ := structpb.NewStruct(input)
+	return s
+}
+
+func newAttributeMap(input map[string]pdata.AttributeValue) pdata.AttributeValue {
+	m := pdata.NewAttributeValueMap()
+	m.MapVal().InitFromMap(input)
+	return m
+}


### PR DESCRIPTION
- remove hardcoded configs
- add unit tests
- detect k8s resources
- fallback defaults for some fields

---
Did some local tests on those changes.

Classical logs:
- New exporter: https://console.cloud.google.com/logs/query;cursorTimestamp=2021-10-27T12:09:22.903Z;quer[…]0Z%2F2021-10-27T12:10:00.000Z?project=collibra-telemetry
- Old exporter: https://console.cloud.google.com/logs/query;cursorTimestamp=2021-10-27T12:09:22.903Z;quer[…]0Z%2F2021-10-27T12:10:00.000Z?project=collibra-telemetry

K8s logs:
- New exporter: https://console.cloud.google.com/logs/query;cursorTimestamp=2021-10-27T14:33:58.544126677[…]0Z%2F2021-10-27T14:34:00.100Z?project=collibra-telemetry
- Old exporter: https://console.cloud.google.com/logs/query;cursorTimestamp=2021-10-27T14:33:59.544087108[…]0Z%2F2021-10-27T14:34:00.100Z?project=collibra-telemetry

To get the GCP K8s container integration working (go to pod/monitoring) we're missing the `cloud.account.id` & `cloud.availability_zone` which seem to not be detected by our current configuration and/or the `resourceprocessor`